### PR TITLE
Fixed panic error while creating Workspace dir for first time

### DIFF
--- a/pkg/confile/confile.go
+++ b/pkg/confile/confile.go
@@ -116,6 +116,7 @@ func (c *confile) Parse(fpath string) error {
 		if err != nil {
 			return err
 		}
+		return nil
 	}
 
 	if !fstat.IsDir() {


### PR DESCRIPTION
Fix this panic error
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x9ddf35]

goroutine 1 [running]:
github.com/CESSProject/DeOSS/pkg/confile.(*confile).Parse(0xc00071b740, {0x160ab25?, 0x3f?})
        /home/alexliu/tehsunnliu/DeOSS/pkg/confile/confile.go:122 +0x435
github.com/CESSProject/DeOSS/cmd/cmd.buildConfigFile(0x182bd05200000000?)
        /home/alexliu/tehsunnliu/DeOSS/cmd/cmd/run.go:210 +0x1bb
github.com/CESSProject/DeOSS/cmd/cmd.cmd_run_func(0xc000004900?, {0x15d98d1?, 0x0?, 0x0?})
        /home/alexliu/tehsunnliu/DeOSS/cmd/cmd/run.go:52 +0x14a
github.com/spf13/cobra.(*Command).execute(0xc000004900, {0x27718a0, 0x0, 0x0})
        /home/alexliu/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:920 +0x847
github.com/spf13/cobra.(*Command).ExecuteC(0x24c3de0)
        /home/alexliu/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        /home/alexliu/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/CESSProject/DeOSS/cmd/cmd.Execute()
        /home/alexliu/tehsunnliu/DeOSS/cmd/cmd/root.go:28 +0x2e
main.main()
        /home/alexliu/tehsunnliu/DeOSS/cmd/main.go:16 +0x17